### PR TITLE
performance crap hueg commit

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -56,22 +56,20 @@ html {
 }
 
 .nav-container {
-    width: 100%;
     border-color: var(--lighter-dark-background);
     border-bottom: 2px solid var(--border-color);
     background-color: var(--lighter-dark-background);
 }
 
 .navigation {
-    width: 100%;
-    font-size: 1.6em;
+    font-size: 1.62em;
     line-height: 100px;
 }
 
 #room {
     background: var(--dark-background);
-    margin-left: 10px;
-    margin-right: 10px;
+    padding-left: 8px;
+    padding-right: 8px;
 }
 
 .header-icon {
@@ -97,7 +95,6 @@ html {
 
 .user-profile {
     text-align: center;
-    width: 100%;
 }
 
 .huge-text {
@@ -111,16 +108,23 @@ html {
 }
 
 #file-list-container {
-    box-sizing: border-box;
+    overflow-x: hidden;
 }
 
-.column, body, html {
+#file-list {
+}
+
+.column, body, html, .container, main {
     display: flex;
     flex-direction: column;
     flex-wrap: nowrap;
     justify-content: flex-start;
     align-items: stretch;
     align-content: flex-start;
+}
+
+#debug-message {
+    margin: 10px;
 }
 
 .column-wrap {
@@ -137,6 +141,10 @@ html {
     align-content: flex-start;
 }
 
+.row-top {
+    align-items: flex-start;
+}
+
 .row-right {
     justify-content: flex-end;
 }
@@ -145,7 +153,7 @@ html {
     justify-content: space-between;
 }
 
-.grow, .wrapped, body {
+.grow, .wrapped, body, .container, main {
     flex-grow: 1;
 }
 
@@ -175,24 +183,36 @@ html {
 
 .scroll-container {
     overflow-y: auto;
+    will-change: transform;
 }
 
 .scroll-content {
     min-height: 100%;
-    width: 100%;
+    will-change: scroll-position;
 }
 
 .auto-basis {
     flex-basis: auto;
 }
 
-.zero-basis, .wrapped, body {
+.zero-basis, .wrapped, body, .container, main {
     flex-basis: 0;
 }
 
+.wrapped, body, .container, main {
+    min-height: 0;
+    max-height: none;
+    min-width: 0;
+    max-width: none;
+}
+
+body, html, .container, main {
+    overflow: hidden;
+}
+
 .file-container {
-    padding-top: 8px;
     padding-bottom: 8px;
+    padding-top: 8px;
     padding-left: 4px;
     padding-right: 3px;
     background-color: var(--lighter-dark-background);
@@ -217,27 +237,49 @@ html {
     font-size: 0.7em;
     margin-left: 5px;
     display: inline-block;
+    flex-shrink: 4;
 }
 
-.file-right, .file-left {
+.file-main {
     display: flex;
     flex-direction: row;
-    flex-wrap: wrap;
+    flex-wrap: nowrap;
+    justify-content: space-between;
     align-items: baseline;
+    align-content: flex-start;
 }
 
-.file-right {
-    text-align: right;
-    flex: 1 1 auto;
-    justify-content: flex-end;
-    align-content: flex-end;
+.file-container, .file-main, .file-left, .file-right, .file-link, .file-expiration, .file-uploader {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    min-width: 0;
+}
+
+.file-container, .file-main, .file-left, .file-right {
+    height: 1.62em;
+    min-height: 0;
 }
 
 .file-left {
-    text-align: left;
-    flex: 4.2 1 auto;
+    display: flex;
+    flex-direction: row;
+    flex-wrap: nowrap;
+    align-items: baseline;
     justify-content: flex-start;
     align-content: flex-start;
+    flex: 1 0 0;
+    text-align: left;
+}
+
+.file-right {
+    display: flex;
+    flex-direction: row;
+    flex-wrap: nowrap;
+    align-items: baseline;
+    justify-content: flex-end;
+    align-content: flex-end;
+    text-align: right;
 }
 
 [v-cloak] {
@@ -245,7 +287,12 @@ html {
 }
 
 .form-group {
-    margin: 10px;
+    margin-top: 8px;
+    margin-bottom: 8px;
+}
+
+.form-group + .form-group {
+    margin-left: 8px;
 }
 
 #dim-screen {
@@ -359,6 +406,10 @@ html {
 .control-bar {
 }
 
+body {
+    margin: 0;
+}
+
 .presence-container-medium {
     max-height: 50vh;
 }
@@ -368,20 +419,26 @@ html {
 }
 
 .container-hide {
-    visibility: collapse;
+    /*visibility: collapse; doesn't work in chrome yet*/
+    display: none;
 }
 
 .container-half {
     max-height: 50vh;
 }
 
-.hovery .file-container .thumbnail {
+.hovery .file-container #thumbnail {
     position: absolute;
     background: var(--upload-bg);
-    left: var(--x);
-    top: var(--y);
     overflow: hidden;
     z-index: 1;
+    top: 0;
+    left: 0;
+    will-change: transform;
+}
+
+.not-hovery .info-displayed {
+    height: auto;
 }
 
 .button, .custom-file-upload, button {
@@ -391,9 +448,9 @@ html {
     display: block;
     cursor: pointer;
     color: var(--upload-text);
-    font-size: 0.9em;
+    font-size: 0.79em;
     font-weight: bold;
-    padding: 11px 23px;
+    padding: 5px 8px;
     text-decoration: none;
     text-align: center;
 }
@@ -408,13 +465,13 @@ html {
 }
 
 .small.delete.button, .mark {
-    margin: 1px 3px 1px 3px;
     padding: 0;
     display: inline-block;
+    margin: 1px 3px 1px 3px;
 }
 
 .row-centre {
-    align-content: center;
+    align-items: center;
 }
 
 .file-odd {
@@ -448,8 +505,4 @@ html {
 
 .hidden {
     display: none;
-}
-
-.container, main, #file-dropzone {
-    display: contents;
 }

--- a/assets/js/file-list-view.js
+++ b/assets/js/file-list-view.js
@@ -59,18 +59,38 @@ export default function(room) {
             },
             filteredFilesLength() {
                 return this.filteredFiles.length;
-            },
-            styleVars() {
-                return {
-                    '--x': this.mouse.x + "px",
-                    '--y': this.mouse.y + "px",
-                };
             }
         },
         methods: {
             mouseMove(e) {
-                this.mouse.x = e.pageX + 1;
-                this.mouse.y = e.pageY + 1;
+                if (!this.hovery) {
+                    return;
+                }
+
+                let target = e.target;
+
+                while (true) {
+                    if (target == e.currentTarget) {
+                        return;
+                    } else {
+                        if (target.classList.contains("file-container")) {
+                            const thumb = target.firstChild.nextElementSibling;
+
+                            if (thumb) {
+                                const rect = e.currentTarget.getBoundingClientRect();
+
+                                thumb.style.setProperty(
+                                    "transform",
+                                    `translate(${e.clientX + 1 - rect.left}px, ${e.clientY + 1 - rect.top}px)`
+                                );
+                            }
+
+                            return;
+                        } else {
+                            target = target.parentElement;
+                        }
+                    }
+                }
             },
             async wake() {
                 return await this.$data.wakeUploader();

--- a/assets/js/settings-view.js
+++ b/assets/js/settings-view.js
@@ -34,7 +34,7 @@ export default {
                 {
                     name: "Hovery thumbs",
                     key: "hover",
-                    value: false
+                    value: true
                 }
             ];
         }

--- a/lib/qtfile_web/templates/room/room.html.eex
+++ b/lib/qtfile_web/templates/room/room.html.eex
@@ -1,8 +1,8 @@
-<div id="file-dropzone">
-  <div id="room" class="grow zero-basis column">
+<div id="file-dropzone" class="container">
+  <div id="room" class="container">
     <div v-if="false" id="dim-screen"><div id="loading-message">Loading</div></div>
 
-    <div v-cloak class="control-bar row">
+    <div v-cloak class="control-bar row row-centre">
       <template>
         <div class="form-group">
           <label for="upload-button" class="custom-file-upload">
@@ -25,7 +25,7 @@
       </template>
 
       <template v-if="mod">
-        <div :class="['presence-container', 'form-group', 'grow', 'scroll-container', { 'presence-container-small': presenceSmall, 'presence-container-big': presenceBig, 'presence-container-medium': presenceMedium }]">
+        <div class="presence-container form-group scroll-container" :class="{ 'presence-container-small': presenceSmall, 'presence-container-big': presenceBig, 'presence-container-medium': presenceMedium }">
           <span is="presence" :presence-hidden="presenceHidden" v-on:toggle-presence="togglePresence" :role="role" :owner="owner" />
         </div>
       </template>
@@ -33,14 +33,14 @@
       <span is="settings" :mod="mod" :set-user-settings="setUserSettings" :save-settings="saveSettings" :set-settings-callback="setSettingsCallback" />
     </div>
 
-    <div v-cloak id="file-list-container" class="grow zero-basis scroll-container">
+    <div v-cloak id="file-list-container" class="wrapped scroll-container">
       <span is="file-list" :role="role" :owner="owner" :filter="filter" :settings="settings" />
     </div>
   </div>
 </div>
 
 <template id="file-list-template">
-  <div id="file-list"  :style="styleVars" v-on:mousemove="mouseMove" class="scroll-content" :class="{'hovery': hovery}">
+  <div id="file-list" v-on:mousemove="mouseMove" class="scroll-content" :class="{ 'hovery': hovery, 'not-hovery': !hovery }">
     <template v-for="(upload, index) in uploads">
       <span is="upload" :wake="wake" :pause="pause" :id="upload.id" :key="upload.id" :role="role" :index="index" :owner="owner" />
     </template>
@@ -70,31 +70,33 @@
 </template>
 
 <template id="file-template">
-  <div :id="domId" class="file-container" :class="{ 'file-odd': phase }">
-    <div class="row row-spaced">
+  <div :id="domId" class="file-container" :class="{ 'file-odd': phase, 'info-displayed': displayInfoHere }">
+    <div class="file-main">
       <div class="file-left" v-on:mouseenter="showMyInfo" v-on:mouseleave="hideMyInfo">
         <a target="_blank" :href="link" class="file-link" :data-hash-sha1="hash">{{ filename }}</a>
         <span class="file-uploader">{{ uploader }}</span>
         <template v-if="mod">
-          <div class="container">
-            <span class="file-uploader">{{ ip_address }}</span>
-            <span is="async-button" :default-icon="128683" :action="banUploader"></span>
-          </div>
+          <span class="file-uploader">{{ ip_address }}</span>
+        </template>
+        <template v-if="mod">
+          <span is="async-button" :default-icon="128683" :action="banUploader"></span>
         </template>
       </div>
       <div class="file-right">
         <span class="file-expiration">{{ formattedExpirationDate }}</span>
         <template v-if="mod">
-          <div class="container">
-            <input class="mark" type="checkbox" v-model="marked">
-            <span is="async-button" :default-icon="128465" :action="deleteMe"></span>
-            <span is="async-button" :default-icon="128683" :action="banMe"></span>
-          </div>
+          <input class="mark" type="checkbox" v-model="marked">
+        </template>
+        <template v-if="mod">
+          <span is="async-button" :default-icon="128465" :action="deleteMe"></span>
+        </template>
+        <template v-if="mod">
+          <span is="async-button" :default-icon="128683" :action="banMe"></span>
         </template>
       </div>
     </div>
     <template v-if="displayInfoHere">
-      <div class="row thumbnail">
+      <div class="row row-top" id="thumbnail">
         <template v-if="videoPreviews.length > 0">
           <video autoplay loop>
             <template v-for="p in videoPreviews">
@@ -124,22 +126,28 @@
 
 
 <template id="async-button-template">
-  <div class="container">
-    <div v-show="status == 'ready'" v-on:click="click" class="small delete button">
+  <span v-on:click="click" class="small delete button">
+    <template v-if="status == 'ready'">
       {{ readyString }}
-    </div>
-    <div v-show="status == 'waiting'" class="small delete button">⌛</div>
-    <div v-show="status == 'failed'" class="small delete button">❌</div>
-    <div v-show="status == 'succeeded'" v-on:click="click" class="small delete button">✓</div>
-  </div>
+    </template>
+    <template v-else-if="status == 'waiting'">
+      ⌛
+    </template>
+    <template v-else-if="status == 'failed'">
+      ❌
+    </template>
+    <template v-else-if="status == 'succeeded'">
+      ✓
+    </template>
+  </span>
 </template>
 
 <template id="presence-template">
-  <div class="scroll-content presence">
+  <div class="scroll-content presence column">
     <div v-on:click="togglePresence" class="button">Presences</div>
-    <div class="column">
+    <div class="column column-wrap" :class="{ 'container-hide': hidden }">
       <template v-for="(user, id) in presences">
-        <div :class="[ { 'container-hide': hidden } ]">
+        <div class="row row-top">
           {{ user.user.name }}/{{ user.user.role }}:
           <div class="column">
             <template v-for="meta in user.metas">
@@ -156,8 +164,8 @@
 </template>
 
 <template id="settings-template">
-  <div class="form-group grow scroll-container container-half">
-    <div class="scroll-content">
+  <div class="form-group scroll-container container-half">
+    <div class="scroll-content column">
       <div v-on:click="toggle" class="button">Settings</div>
       <div class="column column-wrap" :class="{ 'container-hide': hidden }">
         <template v-if="mod">

--- a/lib/qtfile_web/templates/rooms/index.html.eex
+++ b/lib/qtfile_web/templates/rooms/index.html.eex
@@ -1,6 +1,8 @@
-<div id="room-list">
-  <span id="room-id-heading">id</span>
-  <span id="room-name-heading">Room</span>
-  <span id="room-owner-heading">Owner</span>
-  <%= print_all_rooms(@logged_in) %>
+<div id="room-list-container" class="scroll-container">
+  <div id="room-list" class="scroll-content">
+    <span id="room-id-heading">id</span>
+    <span id="room-name-heading">Room</span>
+    <span id="room-owner-heading">Owner</span>
+    <%= print_all_rooms(@logged_in) %>
+  </div>
 </div>

--- a/lib/qtfile_web/templates/shared/header.html.eex
+++ b/lib/qtfile_web/templates/shared/header.html.eex
@@ -1,5 +1,5 @@
 <div class="nav-container row row-spaced">
-  <div class="header-icon row grow shrink">
+  <div class="header-icon row grow">
     <a href="/"><img id="header-image" src="/images/favicon.png" alt="this is the website logo"/></a>
     <span class="qtstream">qtfile</span>
     <%= for %{text: text, url: url, condition: condition} <- @header_elements do %>
@@ -10,7 +10,7 @@
   </div>
 
   <%= if Mix.env == :dev do %>
-    <div class="red grow-double shrink">THIS IS A DEV VERSION OF THE SITE. PLEASE DO NOT USE. PASSWORDS ARE SAVED IN PLAINTEXT IN DEV ENVIRONMENT</div>
+    <div class="red grow-double" id="debug-message">THIS IS A DEV VERSION OF THE SITE. PLEASE DO NOT USE. PASSWORDS ARE SAVED IN PLAINTEXT IN DEV ENVIRONMENT</div>
   <%= end %>
 </div>
 


### PR DESCRIPTION
unnecessary rule removal

add file-main class and set flex-basis to 0 on file-rght/left

fix presence and setting sizes

get rid of stuff placed in :class unnecessarily

remove inner uses of container

use v-if instead of v-show to reduce number of divs in a file

stop using display: contents for wrapping divs

use display none instead of visbility collapse to workaround chrome

make room wrap so control-bar can be next to files

use wrapped instead of grow zero-basis

shrink is default so not needed

give debug message a margin

set min-height to zero on containers and wrapped

don't make presence or settings grow

button container

file-uploader-container

get rid of inline block displays that don't make sense

don't set basis or shrink

inline row into file-uploader-container

file mod controls class

ellipsis when can't wrap

column wrap still doesnt work

change default hover setting to true

white-space property value fuckup

thumb shit needs aligning to top

presences also needs top alignment

button container does not need margins

width is not needed either

height/width/overflow stuff

this stuff needs to be on 'containers' (elements that wrap a single
element in a flex and are themselves in a flex context) but not
'wrapped' items (which are just in a flex context and need to grow).
these elements also do not need overflow, and room should be a
container rather than a "wrapped column" since it's basically the same
thing anyway

mod controls are at the end

flatten files a bit by removing divs

nowrap, fixed height and fixed bsis

remove padding :^)

button revamp

tweak size of right div

the return!

shrink is pointless if basis is 0

removing padding was a mistake

make thumbnail into an id since there is only one at a time

mouse movement: bypass vue and use transform

fix accordion!

flatten out file-right

some confusion between flex containers and items

it is flex items that need min-height: 0 etc, rather than divs with
display: flex so html is removed and wrapped is added. the overflow
part is taken out because that really does only need to be set on flex
divs

margin and stretch removal

this was done together because removing stretch and adding width: 100%
to replace it suddenly reveals all the margins by misaligning everything

workaround for the palemoon button alignment meltdown

this needs removing if/or palemoon is ever updated and fixed

why bother with a min height

get rid of one last horizontal scrollbar

turns out stretch was faster all along

pointless accuracy

turns out file-right was faster all along

improve scrolling performance

more will-change optimisation

set style directly instead of using variables

fix accordion thumbs again

fix positioning

I know I should stop fucking with these but I can't help it

scroll optimisation for everyone!

add scrolling to rooms list

padding improvement

remove divider cos it looks dumb

make buttons smaller